### PR TITLE
[WIP] Add support for prefixing with baseHref

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Angular named route
 ===========================
-Named route support for angular-route. Name your routes so you don't have to copy-paste-replace url everywhere.
+
+Named route support for angular-route. Name your routes so you don't have to copy-paste-replace URLs everywhere. Automatically prefixes [`<base />` href][rellink] so that all links created work in HTML 5 mode.
+
+[rellink]: https://docs.angularjs.org/guide/$location#relative-links
+
 # Install
 
-```sh 
+```sh
 bower install angular-named-route --save
 ```
 
@@ -33,21 +37,21 @@ angular.module('myapp').config(function($routeProvider) {
 //use as a service
 angular.module('myapp').controller('ThingCtrl', function (namedRouteService, $location) {
     var path;
-    
+
     //reverse to get path string
-    path = namedRouteService.reverse('home'); 
+    path = namedRouteService.reverse('home');
     //path = '/'
 
     //single param
-    path = namedRouteService.reverse('thing-detail', 1); 
+    path = namedRouteService.reverse('thing-detail', 1);
     //path = '/thing/1'
 
     //param list
-    path = namedRouteService.reverse('thing-detail', [1]); 
+    path = namedRouteService.reverse('thing-detail', [1]);
     //path = '/thing/1'
 
     //param object
-    path = namedRouteService.reverse('thing-detail', {id: 1}); 
+    path = namedRouteService.reverse('thing-detail', {id: 1});
     //path = '/thing/1'
 
     //query arguments

--- a/bower.json
+++ b/bower.json
@@ -20,11 +20,11 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.4.2",
-    "angular-route": "~1.4.2"
+    "angular": "^1.4.2",
+    "angular-route": "^1.4.2"
     
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.2"
+    "angular-mocks": "^1.4.2"
   }
 }

--- a/src/named-route-service.js
+++ b/src/named-route-service.js
@@ -71,10 +71,9 @@ angular.module('ngNamedRoute').provider('namedRouteService', function ($location
             if ($browser.baseHref() === '/') {
                 // No need to append '/'
                 return url;
-            } else {
-                // Prepend the base href
-                return $browser.baseHref() + url;
             }
+            // Prepend the base href
+            return $browser.baseHref() + url;
         }
 
         return {

--- a/src/named-route-service.js
+++ b/src/named-route-service.js
@@ -1,22 +1,6 @@
 angular.module('ngNamedRoute').provider('namedRouteService', function ($locationProvider) {
     'use strict';
 
-    /** Internal configuration variable. */
-    var shouldAlwaysPrefixBase = false;
-
-    /**
-     * Sets whether the service should always prefix the <base href />.
-     */
-    this.alwaysPrefixBase = function (value) {
-        if (value === undefined) {
-            return shouldAlwaysPrefixBase;
-        }
-
-        shouldAlwaysPrefixBase = value;
-
-        return this;
-    };
-
     this.$get = /*@ngInject*/ function ($route, $location, $browser) {
         //map name to route
         var routemap = {};
@@ -84,16 +68,13 @@ angular.module('ngNamedRoute').provider('namedRouteService', function ($location
                 }).join('&');
             }
 
-            if (shouldAlwaysPrefixBase) {
-                if ($browser.baseHref() === '/') {
-                    // No need to append '/'
-                    return url;
-                }
+            if ($browser.baseHref() === '/') {
+                // No need to append '/'
+                return url;
+            } else {
                 // Prepend the base href
                 return $browser.baseHref() + url;
             }
-
-            return url;
         }
 
         return {

--- a/src/named-route-service.js
+++ b/src/named-route-service.js
@@ -1,6 +1,22 @@
 angular.module('ngNamedRoute').provider('namedRouteService', function ($locationProvider) {
     'use strict';
 
+    /** Internal configuration variable. */
+    var shouldAlwaysPrefixBase = false;
+
+    /**
+     * Sets whether the service should always prefix the <base href />.
+     */
+    this.alwaysPrefixBase = function (value) {
+        if (value === undefined) {
+            return shouldAlwaysPrefixBase;
+        }
+
+        shouldAlwaysPrefixBase = value;
+
+        return this;
+    };
+
     this.$get = /*@ngInject*/ function ($route, $location, $browser) {
         //map name to route
         var routemap = {};
@@ -68,13 +84,16 @@ angular.module('ngNamedRoute').provider('namedRouteService', function ($location
                 }).join('&');
             }
 
-            if ($browser.baseHref() === '/') {
-                // No need to append '/'
-                return url;
-            } else {
+            if (shouldAlwaysPrefixBase) {
+                if ($browser.baseHref() === '/') {
+                    // No need to append '/'
+                    return url;
+                }
                 // Prepend the base href
                 return $browser.baseHref() + url;
             }
+
+            return url;
         }
 
         return {

--- a/src/named-route-service.js
+++ b/src/named-route-service.js
@@ -1,7 +1,7 @@
 angular.module('ngNamedRoute').provider('namedRouteService', function ($locationProvider) {
     'use strict';
 
-    this.$get = /*@ngInject*/ function ($route, $location) {
+    this.$get = /*@ngInject*/ function ($route, $location, $browser) {
         //map name to route
         var routemap = {};
 
@@ -67,7 +67,14 @@ angular.module('ngNamedRoute').provider('namedRouteService', function ($location
                     return key + '=' + encodeURIComponent(val);
                 }).join('&');
             }
-            return url;
+
+            if ($browser.baseHref() === '/') {
+                // No need to append '/'
+                return url;
+            } else {
+                // Prepend the base href
+                return $browser.baseHref() + url;
+            }
         }
 
         return {

--- a/test/init-browser.js
+++ b/test/init-browser.js
@@ -1,0 +1,23 @@
+/**
+ * Initializes a broswer with the given url and basePath.
+ *
+ * Usage:
+ *
+ *    inject(
+ *      initBrowser({ url: 'http://example.org/path/', basePath: '/path' }),
+ *      function () {
+ *        // test goes here.
+ *      }
+ *    )
+ *
+ * Copied From: https://github.com/angular/angular.js/blob/fa79eaa816aa27c6d1b3c084b8372f9c17c8d5a3/test/ng/locationSpec.js#L2630,L2635
+ *
+ * @param {Object} options  url and basePath
+ * @returns {Function}      injectable function.
+ */
+this.initBrowser = function (options) {
+  return function($browser) {
+    $browser.url(options.url);
+    $browser.$$baseHref = options.basePath;
+  };
+};

--- a/test/named-route-directive.spec.js
+++ b/test/named-route-directive.spec.js
@@ -128,11 +128,4 @@ describe('namedRouteService_base', function () {
     );
   });
 
-  /* From: https://github.com/angular/angular.js/blob/fa79eaa816aa27c6d1b3c084b8372f9c17c8d5a3/test/ng/locationSpec.js#L2630,L2635 */
-  function initBrowser(options) {
-    return function($browser) {
-      $browser.url(options.url);
-      $browser.$$baseHref = options.basePath;
-    };
-  }
 });

--- a/test/named-route-directive.spec.js
+++ b/test/named-route-directive.spec.js
@@ -69,7 +69,7 @@ describe("namedRouteDirective", function () {
 describe('namedRouteDirective_hash', function () {
   beforeEach(module('testmodule_hash'));
 
-  var namedRouteService, $compile, $rootScope;
+  var $compile, $rootScope;
 
   beforeEach(inject(function(_$compile_, _$rootScope_){
     $compile = _$compile_,

--- a/test/named-route-directive.spec.js
+++ b/test/named-route-directive.spec.js
@@ -95,7 +95,7 @@ describe('namedRouteDirective_hash', function () {
 });
 
 describe('namedRouteService_base', function () {
-  beforeEach(module('testmodule'));
+  beforeEach(module('testmodule_base'));
 
   var $compile, $rootScope;
 

--- a/test/named-route-directive.spec.js
+++ b/test/named-route-directive.spec.js
@@ -93,3 +93,46 @@ describe('namedRouteDirective_hash', function () {
   });
 
 });
+
+describe('namedRouteService_base', function () {
+  beforeEach(module('testmodule'));
+
+  var $compile, $rootScope;
+
+  beforeEach(inject(function(_$compile_, _$rootScope_){
+    $compile = _$compile_,
+    $rootScope = _$rootScope_;
+  }));
+
+  it('updates href with hashed home route', function() {
+    inject(
+      initBrowser({ url: 'http://host.com/prefix/', basePath: '/prefix' }),
+      function () {
+        var element = $compile('<div><a named-route="\'home\'">link</a></div>')($rootScope);
+        $rootScope.$digest();
+        expect(element.find('a').attr('href')).toEqual('/prefix/');
+      }
+    );
+  });
+
+  it('updates href with phone detail route, single arg', function() {
+    inject(
+      initBrowser({ url: 'http://host.com/prefix/', basePath: '/prefix' }),
+      function () {
+        $rootScope.hrefname = 'the link';
+        var element = $compile('<div><a named-route="\'phone-detail\'" route-params="1">{{hrefname}}</a></div>')($rootScope);
+        $rootScope.$digest();
+        expect(element.find('a').attr('href')).toEqual('/prefix/phones/1');
+        expect(element.html()).toContain('the link');
+      }
+    );
+  });
+
+  /* From: https://github.com/angular/angular.js/blob/fa79eaa816aa27c6d1b3c084b8372f9c17c8d5a3/test/ng/locationSpec.js#L2630,L2635 */
+  function initBrowser(options) {
+    return function($browser) {
+      $browser.url(options.url);
+      $browser.$$baseHref = options.basePath;
+    };
+  }
+});

--- a/test/named-route-directive.spec.js
+++ b/test/named-route-directive.spec.js
@@ -95,7 +95,7 @@ describe('namedRouteDirective_hash', function () {
 });
 
 describe('namedRouteService_base', function () {
-  beforeEach(module('testmodule_base'));
+  beforeEach(module('testmodule'));
 
   var $compile, $rootScope;
 

--- a/test/named-route-service.spec.js
+++ b/test/named-route-service.spec.js
@@ -78,7 +78,7 @@ describe('namedRouteService_hash', function () {
 });
 
 describe('namedRouteService_base', function () {
-  beforeEach(module('testmodule_base'));
+  beforeEach(module('testmodule'));
 
   var namedRouteService;
 

--- a/test/named-route-service.spec.js
+++ b/test/named-route-service.spec.js
@@ -87,15 +87,6 @@ describe('namedRouteService_base', function () {
     namedRouteService = _namedRouteService_;
   }));
 
-
-  /* From: https://github.com/angular/angular.js/blob/fa79eaa816aa27c6d1b3c084b8372f9c17c8d5a3/test/ng/locationSpec.js#L2630,L2635 */
-  function initBrowser(options) {
-    return function($browser) {
-      $browser.url(options.url);
-      $browser.$$baseHref = options.basePath;
-    };
-  }
-
   it('resolves home route including base href', function() {
     inject(
       initBrowser({ url: 'http://host.com/prefix/', basePath: '/prefix' }),

--- a/test/named-route-service.spec.js
+++ b/test/named-route-service.spec.js
@@ -113,7 +113,7 @@ describe('namedRouteService_base', function () {
   it('resolves phone route detail route using single parameter with base href', function() {
     inject(
       initBrowser({ url: 'http://host.com/prefix/', basePath: '/prefix' }),
-      function ($location, $browser) {
+      function () {
         expect(namedRouteService.reverse('phone-detail', 2)).toEqual('/prefix/phones/2');
       }
     );

--- a/test/named-route-service.spec.js
+++ b/test/named-route-service.spec.js
@@ -78,7 +78,7 @@ describe('namedRouteService_hash', function () {
 });
 
 describe('namedRouteService_base', function () {
-  beforeEach(module('testmodule'));
+  beforeEach(module('testmodule_base'));
 
   var namedRouteService;
 

--- a/test/named-route-service.spec.js
+++ b/test/named-route-service.spec.js
@@ -76,3 +76,37 @@ describe('namedRouteService_hash', function () {
   });
 
 });
+
+describe('namedRouteService_base', function () {
+  beforeEach(module('testmodule'));
+
+  var namedRouteService;
+
+  beforeEach(inject(function(_namedRouteService_){
+    // The injector unwraps the underscores (_) from around the parameter names when matching
+    namedRouteService = _namedRouteService_;
+  }));
+
+
+  /* From: https://github.com/angular/angular.js/blob/fa79eaa816aa27c6d1b3c084b8372f9c17c8d5a3/test/ng/locationSpec.js#L2630,L2635 */
+  function initBrowser(options) {
+    return function($browser) {
+      $browser.url(options.url);
+      $browser.$$baseHref = options.basePath;
+    };
+  }
+
+  it('resolves home route including base href', function() {
+    inject(
+      initBrowser({ url: 'http://host.com/prefix/', basePath: '/prefix' }),
+      function ($location, $browser) {
+        // Sanity check: location.path() should be at the root.
+        expect($location.path()).toEqual('/');
+        // Sanity check: location.baseHref() should be what we expect.
+        expect($browser.baseHref()).toEqual('/prefix');
+
+        expect(namedRouteService.reverse('home', undefined)).toEqual('/prefix/');
+      }
+    );
+  });
+});

--- a/test/named-route-service.spec.js
+++ b/test/named-route-service.spec.js
@@ -109,4 +109,13 @@ describe('namedRouteService_base', function () {
       }
     );
   });
+
+  it('resolves phone route detail route using single parameter with base href', function() {
+    inject(
+      initBrowser({ url: 'http://host.com/prefix/', basePath: '/prefix' }),
+      function ($location, $browser) {
+        expect(namedRouteService.reverse('phone-detail', 2)).toEqual('/prefix/phones/2');
+      }
+    );
+  });
 });

--- a/test/testmodule.js
+++ b/test/testmodule.js
@@ -38,30 +38,3 @@ angular.module('testmodule_hash', ['ngRoute', 'ngNamedRoute']).config(function($
       name: 'phone-detail'
     });
 });
-
-angular.module('testmodule_base', ['ngRoute', 'ngNamedRoute']).config(function($routeProvider, $locationProvider, namedRouteServiceProvider) {
-    $locationProvider.html5Mode(true);
-    namedRouteServiceProvider.alwaysPrefixBase(true);
-    $routeProvider.
-      when('/', {
-        controller: 'PhoneListCtrl',
-        name: 'home'
-      }).
-      when('/phones/:phoneId', {
-        templateUrl: 'partials/phone-detail.html',
-        controller: 'PhoneDetailCtrl',
-        name: 'phone-detail'
-      })
-      .when('/phones/:phoneId/models/:modelId', {
-        controller: 'PhoneModelDetailCtrl',
-        name: 'phone-model-detail'
-      })
-      .when('/optional/:subpath?', {
-        controller: 'PhoneModelDetailCtrl',
-        name: 'optional-param-route'
-      })
-      .when('/admin/:page*/view', {
-        controller: 'AdminCtrl',
-        name: 'admin-greedy'
-      })
-});

--- a/test/testmodule.js
+++ b/test/testmodule.js
@@ -38,3 +38,30 @@ angular.module('testmodule_hash', ['ngRoute', 'ngNamedRoute']).config(function($
       name: 'phone-detail'
     });
 });
+
+angular.module('testmodule_base', ['ngRoute', 'ngNamedRoute']).config(function($routeProvider, $locationProvider, namedRouteServiceProvider) {
+    $locationProvider.html5Mode(true);
+    namedRouteServiceProvider.alwaysPrefixBase(true);
+    $routeProvider.
+      when('/', {
+        controller: 'PhoneListCtrl',
+        name: 'home'
+      }).
+      when('/phones/:phoneId', {
+        templateUrl: 'partials/phone-detail.html',
+        controller: 'PhoneDetailCtrl',
+        name: 'phone-detail'
+      })
+      .when('/phones/:phoneId/models/:modelId', {
+        controller: 'PhoneModelDetailCtrl',
+        name: 'phone-model-detail'
+      })
+      .when('/optional/:subpath?', {
+        controller: 'PhoneModelDetailCtrl',
+        name: 'optional-param-route'
+      })
+      .when('/admin/:page*/view', {
+        controller: 'AdminCtrl',
+        name: 'admin-greedy'
+      })
+});


### PR DESCRIPTION
@domasx2 ~~This patch as it is now adds backwards-incompatible changes! Basically, it **always** prefixes the baseHref, if it's set and not the default. This will break if users have a `<base>` href set (and perhaps simply using `$location.path()`, since it takes care of this `<base>` non-sense).~~

**EDIT**: I implemented the provider option, as described below.

I figure this feature can be safely added without breaking backwards compatibility in at least two ways:
-  add `namedRouteProvider` that is configurable with an option to always prefix all links with the baseHref
  
  ``` js
  angular.module('app', ['ng', 'ngNamedRoute']).config(function (namedRouteServiceProvider) {
     namedRouteServiceProvider.alwaysPrefixBase(true);
  });
  ```
- add an fourth argument to `namedRouteService#reverse()` (and perhaps another attribute for `<a named-route>`) to explicitly prefix with the `baseHref`.

TODO:
- [x] Tests for directive
- [x] Create a provider?
- [X] ~~OR: Add an extra argument to `namedRouteService#reverse()`~~
- [x] Make base prefixing the default
- [x] Add feature documentation to the README
- [x] Fix issue #7?
- [x] Publish this in next ~~minor~~ major release (3.0.0)
